### PR TITLE
Danger only runs on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,4 +91,8 @@ workflows:
     jobs:
       - build
       - rubocop
-      - danger
+      - danger:
+          filters:
+            branches:
+              ignore:
+                - master


### PR DESCRIPTION
Because danger makes no sense on master. It even crashes.