### PR TITLE
Extract results even when tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,14 @@ jobs:
 
       # run tests!
       - run:
-          name: run tests
+          name: prepare test container
           command: |
-            mkdir /tmp/test-results
+            mkdir -p /tmp/test-results
             docker-compose -f .circleci/compose.yml exec rails mkdir /tmp/test-results
 
+      - run:
+          name: run tests
+          command: |
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \
               circleci tests split --split-by=timings)"
 
@@ -49,6 +52,10 @@ jobs:
               --format progress \
               $TEST_FILES
 
+      - run:
+          name: extract results
+          when: always
+          command: |
             docker cp rails:/tmp/test-results/rspec.xml /tmp/test-results/rspec.xml
 
       # collect reports


### PR DESCRIPTION
Tests fail, but the circle ci config does not upload if tests fail. This PR fixes that.