### PR TITLE
Exclude vendor dir from cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'bin/setup'
     - 'bin/update'
     - 'lib/templates/**/*'
+    - 'vendor/**/*'
 
 Style/Documentation:
   Exclude:


### PR DESCRIPTION
Because installing into vendor dir causes rubocop to check there too