### PR TITLE
Display docker logs when container fails to start

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,11 @@ jobs:
             bash -c 'while [[ "$(docker-compose -f .circleci/compose-unit.yml exec rails-unit curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3000/api/v1/health)" != "200" ]]; do sleep 1; printf "."; done'
 
       - run:
+          name: display docker log for failed container start
+          command: docker logs rails-unit
+          when: on_fail
+
+      - run:
           name: run tests
           command: |
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | \


### PR DESCRIPTION
This is so we can see what happened inside the container while waiting for it.