### PR TITLE
More info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,11 +98,12 @@ jobs:
       - run:
           name: wait for container to ready
           command : |
-            bash -c 'while [[ "$(docker-compose -f .circleci/compose-unit.yml exec rails-unit curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3000/api/v1/health)" != "200" ]]; do sleep 1; printf "."; done'
+            docker ps -a
+            timeout 15 bash -c -- 'while [[ "$(docker-compose -f .circleci/compose-unit.yml exec rails-unit curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3000/api/v1/health)" != "200" ]]; do sleep 1; printf "."; done'
 
       - run:
           name: display docker log for failed container start
-          command: docker logs rails-unit
+          command: docker-compose -f .circleci/compose-unit.yml logs rails-unit
           when: on_fail
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           name: wait for container to ready
           command : |
             docker ps -a
-            timeout 15 bash -c -- 'while [[ "$(docker-compose -f .circleci/compose-unit.yml exec rails-unit curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3000/api/v1/health)" != "200" ]]; do sleep 1; printf "."; done'
+            timeout 60 bash -c -- 'while [[ "$(docker-compose -f .circleci/compose-unit.yml exec rails-unit curl -s -o /dev/null -w ''%{http_code}'' http://localhost:3000/api/v1/health)" != "200" ]]; do sleep 1; printf "."; done'
 
       - run:
           name: display docker log for failed container start

--- a/docker/unit/Procfile
+++ b/docker/unit/Procfile
@@ -1,4 +1,4 @@
 postgres: postgres -D /srv/postgres
 redis: redis-server
 rails: rails assets:precompile; sh waitpg.sh; rails db:create; rails db:migrate; rails db:seed; sh waitredis.sh; bundle exec rails s -b 0.0.0.0 -p 3000
-sidekiq: sh waitpg.sh && sh waitredis.sh && bundle exec sidekiq -C config/sidekiq.yml
+sidekiq: sh waitpg.sh && sh waitredis.sh && sleep 5 && bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
Timeout the problematic curl and print docker info beforehand.

Running two things loaded by bootsnap using foreman might have interfered with its caching mechanism. Inserted a delay to sidekiq startup to fix it.
