### PR TITLE
fix papertrail ulid reload issue

### DIFF
--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  # Extension to allow papertrail versions to use ULID
+  class Version < ActiveRecord::Base
+    include PaperTrail::VersionConcern
+    include ULID::Rails
+    ulid :id
+    ulid :item_id
+  end
+end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,12 +1,3 @@
 # frozen_string_literal: true
 
 PaperTrail::Rails::Engine.eager_load!
-
-module PaperTrail
-  # Extension to allow papertrail versions to use ULID
-  class Version < ActiveRecord::Base
-    include ULID::Rails
-    ulid :id
-    ulid :item_id
-  end
-end


### PR DESCRIPTION
Papertrail's original docs tell us to place the model in the initializer. But it does not work so well when you are in development and reloading happens.

An answer in stackoverflow seems to solve the issue:

https://stackoverflow.com/questions/31716983/nomethoderror-undefined-method-timestamp-sort-order-for-paper-trail-issue-af