### PR TITLE
Silence test logging

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.logger = nil unless ENV['VERBOSE_TEST']
 end

--- a/spec/browser_helper.rb
+++ b/spec/browser_helper.rb
@@ -19,6 +19,7 @@ else
     Capybara::Selenium::Driver.new(app, browser: :chrome)
   end
 end
+Capybara.server = :puma, { Silent: true }
 
 Capybara.configure do |config|
   config.default_max_wait_time = 10 # seconds


### PR DESCRIPTION
Test logging is noisy and drowns out the test dots. This PR removes them unless specifically asked for.