### PR TITLE
Explicitly load papertrail in initializer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,4 +432,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+require 'paper_trail/version.rb'
 
 PaperTrail::Rails::Engine.eager_load!

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'paper_trail/version.rb'
 
 PaperTrail::Rails::Engine.eager_load!


### PR DESCRIPTION
Rails 6 will deprecate autoload in initializer. We actually don't need it but papertrail's initializer still seems to rely on it so I'll just do this for now.