### PR TITLE
Don't whitelist anything

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module RailsZen
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # Clear hosts in Rails 6. No need to whitelist unless you
+    # really want to.
+    config.hosts.clear
+
     # Settings in config/environments/* take precedence over those specified
     # here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Rails 6 seems to encourage us to whitelist hosts for development but its really unneccessary. This fixes it.