### PR TITLE
Make swagger loadable again on dev

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link grape_swagger_rails/application.js
+//= link grape_swagger_rails/application.css

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module RailsZen
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # Clear hosts in Rails 6. No need to whitelist unless you
+    # really want to.
+    config.hosts.clear
+
     # Settings in config/environments/* take precedence over those specified
     # here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Rails 6 seems to have changed something and swagger assets were no longer in preload