### PR TITLE
Fix an issue with multiple dashes on gitlab runner name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,5 +50,5 @@ test:
     - bundle exec rails db:create
     - bundle exec rails db:migrate
     - bundle exec rails db:test:prepare
-    - echo "$(cat /etc/hosts | grep -Eo "^([0-9\.]+)\s+runner-+[0-9a-zA-Z]*-+project-[0-9a-zA-Z]+-concurrent-[0-9]+" | grep -Eo "^([0-9\.]+)")" > ip_addr
+    - echo "$(cat /etc/hosts | grep -Eo "^([0-9\.]+)\s+runner-[0-9a-zA-Z-]{8}-+project-[0-9a-zA-Z]+-concurrent-[0-9]+" | grep -Eo "^([0-9\.]+)")" > ip_addr
     - TEST_HOST="$(cat ip_addr)" bundle exec rspec

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,5 +50,5 @@ test:
     - bundle exec rails db:create
     - bundle exec rails db:migrate
     - bundle exec rails db:test:prepare
-    - echo "$(cat /etc/hosts | grep -Eo "^([0-9\.]+)\s+runner-[0-9a-zA-Z]*-+project-[0-9a-zA-Z]+-concurrent-[0-9]+" | grep -Eo "^([0-9\.]+)")" > ip_addr
+    - echo "$(cat /etc/hosts | grep -Eo "^([0-9\.]+)\s+runner-+[0-9a-zA-Z]*-+project-[0-9a-zA-Z]+-concurrent-[0-9]+" | grep -Eo "^([0-9\.]+)")" > ip_addr
     - TEST_HOST="$(cat ip_addr)" bundle exec rspec


### PR DESCRIPTION
Some gitlab jobs started failing due to multiple dashes in the runner name

![image](https://user-images.githubusercontent.com/874280/149646577-6676fa09-340d-4cfd-bf71-28dfb3a9517e.png)

https://gitlab.com/davidsiaw/rails-zen/-/jobs/1978214830

Maybe this will fix it.