### PR TITLE
make gid work on macs

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-PUID="$(id -u)" PGID="$(id -g)" docker compose up -d --build
+PUID="$(id -u)" PGID="1000" docker compose up -d --build


### PR DESCRIPTION
make gid work on macs which use gid of 20 but its used in some docker images